### PR TITLE
兼容旧版群聊信息格式,增加typescript支持,更换swc-loader加速build过程

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,366 @@
+declare module 'gewechaty' {
+    export class GeweBot {
+      constructor(options?: GeweBotOptions);
+      db: any; // SQLite database instance
+      use_cache: boolean;
+      start(): Promise<{
+        app: import('koa');
+        router: import('koa-router');
+      }>;
+      on(event: 'message', listener: (msg: Message) => void): void;
+      on(event: 'friendship', listener: (friendship: Friendship) => void): void;
+      on(event: 'room-invite', listener: (roomInvitation: RoomInvitation) => void): void;
+      on(event: 'all', listener: (payload: any) => void): void;
+      on(event: 'scan', listener: (qrcode: QRCode) => void): void;
+      login(): Promise<boolean>;
+      logout(): Promise<boolean>;
+      info(): Promise<ContactSelf>;
+      qrcode(): Promise<string>;
+      getAppId(): string;
+      getToken(): string;
+      getUuid(): string;
+      setInfo(options: ContactSettings): Promise<void>;
+      setPrivacy(options: PrivacySettings): Promise<void>;
+      setAvatar(fileUrl: string): Promise<void>;
+      deviceList(): Promise<Device[]>;
+      refreshContactCache(): Promise<void>;
+      Contact: ContactStatic;
+      Friendship: FriendshipStatic;
+      Room: RoomStatic;
+      Message: MessageStatic;
+    }
+  
+    export interface GeweBotOptions {
+      debug?: boolean;
+      base_api: string;
+      file_api: string;
+      ip?: string;
+      port?: number;
+      proxy?: string;
+      static?: string;
+      route?: string;
+      use_cache?: boolean;
+    }
+  
+    export interface ContactSelf {
+      city: string;
+      country: string;
+      nickName: string;
+      province: string;
+      sex: number;
+      signature: string;
+      wxid: string;
+      name: string;
+      alias: string;
+    }
+  
+    export interface ContactSettings {
+      city?: string;
+      country?: string;
+      nickName?: string;
+      province?: string;
+      sex?: number;
+      signature?: string;
+    }
+  
+    export interface PrivacySettings {
+      option: number;
+      open: boolean;
+    }
+  
+    export interface Device {
+      client_id: string;
+      device_name: string;
+      device_type: string;
+      login_time: number;
+    }
+  
+    export interface QRCode {
+      content: string;
+      url: string;
+    }
+  
+    export class Contact {
+      // Properties from CONTACT.js constructor
+      _name: string;
+      _alias: string;
+      _isFriend: boolean;
+      _wxid: string | null;
+      _type: number;
+      _gender: number;
+      _province: string | null;
+      _city: string | null;
+      _avatarUrl: string;
+      _isSelf: boolean;
+      inviterUserName: string;
+  
+      // Methods from CONTACT.js
+      say(textOrContactOrFileOrUrl: string | Contact | Filebox | UrlLink | MiniApp): Promise<ResponseMsg>;
+      name(): string;
+      alias(newAlias?: string): Promise<string | void>;
+      friend(): boolean;
+      type(): number;
+      gender(): number;
+      province(): string | null;
+      city(): string | null;
+      avatar(): Promise<string>;
+      sync(): Promise<Contact>;
+      self(): boolean;
+  
+      // Static methods
+      static find(query: ContactQueryFilter): Promise<Contact | undefined>;
+      static findAll(query: ContactQueryFilter): Promise<Contact[]>;
+    }
+  
+    export interface ContactStatic {
+      find(query: ContactQueryFilter): Promise<Contact | undefined>;
+      findAll(query: ContactQueryFilter): Promise<Contact[]>;
+    }
+  
+    export interface ContactQueryFilter {
+      name?: string;
+      alias?: string;
+      id?: string;
+    }
+  
+    export class Friendship {
+      accept(): Promise<void>;
+      hello(): string;
+      type(): number;
+    }
+  
+    export interface FriendshipStatic {
+      search(query: string): Promise<Contact | undefined>;
+      add(contact: Contact, hello: string): Promise<void>;
+    }
+  
+    export class RoomInvitation {
+      accept(): Promise<void>;
+    }
+  
+    export class Room {
+      // Properties from ROOM.js constructor
+      chatroomId: string;
+      name: string;
+      remark: string;
+      chatRoomNotify: any;
+      chatRoomOwner: string;
+      isNotify: boolean;
+      OwnerId: string;
+      avatarImg: string;
+      memberList: any[];
+  
+      // Methods from ROOM.js
+      sync(): Promise<Room>;
+      say(textOrContactOrFileOrUrl: string | Contact | Filebox | UrlLink | MiniApp, ats?: Contact[] | '@all'): Promise<ResponseMsg>;
+      on(event: 'join', listener: (room: Room, inviteeList: Contact[], inviter: Contact) => void): void;
+      on(event: 'leave', listener: (room: Room, leaverList: Contact[], remover?: Contact) => void): void;
+      on(event: 'topic', listener: (room: Room, newTopic: string, oldTopic: string, changer: Contact) => void): void;
+      add(contact: Contact | string, reason?: string): Promise<void>;
+      del(contact: Contact | string): Promise<void>;
+      quit(): Promise<void>;
+      topic(newTopic?: string): Promise<string>;
+      announce(text?: string): Promise<string>;
+      qrcode(): Promise<{ qrBase64: string, qrTips: string }>;
+      alias(contact: Contact): Promise<string | null>;
+      has(contact: Contact): Promise<boolean>;
+      memberAll(query?: string): Promise<Contact[]>;
+      member(query: string): Promise<Contact | null>;
+      owner(): Promise<Contact>;
+      avatar(): Promise<Filebox>;
+      rename(name?: string): Promise<string>;
+  
+      // Static methods
+      static create(contactList: Contact[], topic?: string): Promise<Room>;
+      static findAll(query?: RoomQueryFilter): Promise<Room[]>;
+      static find(query: RoomQueryFilter): Promise<Room | undefined>;
+    }
+  
+    export interface RoomStatic {
+      create(contactList: Contact[], topic?: string): Promise<Room>;
+      find(query: RoomQueryFilter): Promise<Room | undefined>;
+      findAll(query?: RoomQueryFilter): Promise<Room[]>;
+    }
+  
+    export interface RoomQueryFilter {
+      topic?: string;
+    }
+  
+    export class Message {
+      // Properties from MESSAGE.js constructor
+      wxid: string;
+      fromId: string;
+      toId: string;
+      isRoom: boolean;
+      roomId: string;
+      _text: string;
+      _msgId: string | null;
+      _newMsgId: string | null;
+      _type: number;
+      _createTime: number;
+      _date: number;
+      _self: boolean;
+      _pushContent: string;
+      _msgSeq: string | null;
+      _status: any | null;
+      _msgSource: string | null;
+      _roomInfo?: any;
+  
+      // Methods from MESSAGE.js
+      isCompanyMsg(): boolean;
+      from(): Promise<Contact>;
+      talker(): Promise<Contact>;
+      to(): Promise<Contact>;
+      room(): Promise<Room | false>;
+      text(): string;
+      say(textOrContactOrFileOrUrl: string | Contact | Filebox | UrlLink | MiniApp | AppMsg | Voice | WeVideo | Emoji): Promise<ResponseMsg>;
+      type(): number;
+      self(): boolean;
+      mention(): Promise<null>; // TODO as noted in the code
+      mentionSelf(): Promise<boolean>;
+      forward(to: Contact): Promise<void>;
+      date(): Date;
+      age(): number;
+      toContact(): Promise<null>; // TODO as noted in the code
+      toUrlLink(): Promise<null>; // TODO as noted in the code
+      toFileBox(type?: number): Promise<Filebox | null>;
+      quote(title: string): Promise<void>;
+
+  
+      // Static methods
+      static getXmlToJson(xml: string): any;
+      static find(query: any): Promise<Message>;
+      static findAll(queryArgs: any): Promise<Message[]>;
+      static getType(type: number, xml: string): number;
+      static revoke(obj: any): Promise<void>;
+    }
+  
+    export interface MessageStatic {
+      Type: {
+        Unknown: 0;
+        Text: 1;
+        Image: number;
+        Voice: number;
+        AddFriend: number;
+        Contact: number;
+        Video: number;
+        Emoji: number;
+        Location: number;
+        Link: number;
+        File: number;
+        RealTimeLocation: number;
+        ChatHistroy: number;
+        MiniApp: number;
+        VideoAccount: number;
+        Quote: number;
+        FileStart: number;
+        Transfer: number;
+        RedPacket: number;
+        Revoke: number;
+        Pat: number;
+        FunctionMsg: number;
+        Voip: number;
+        RoomInvitation: number;
+      };
+    }
+  
+    export class WeVideo {
+      constructor(payload: WeVideoPayload);
+    }
+  
+    export interface WeVideoPayload {
+      thumbUrl: string;      // 视频封面
+      videoUrl: string;      // 视频文件url
+      videoDuration: number; // 视频时长单位秒
+    }
+  
+    export class Voice {
+      constructor(payload: VoicePayload);
+    }
+  
+    export interface VoicePayload {
+      voiceUrl: string;       // 语音文件url
+      voiceDuration: number;  // 语音时长(毫秒)
+    }
+  
+    export class Filebox {
+      // Properties from FILEBOX.js
+      url: string;
+      type: string;
+      name: string;
+  
+      // Static methods from FILEBOX.js
+      static fromUrl(url: string, forceType?: string): Filebox;
+      static fromFile(filepath: string, time?: number): Filebox;
+      static toDownload(url: string, type?: string, name?: string): Filebox;
+      static getFileType(fileName: string): 'image' | 'video' | 'audio' | 'file' | 'unknown';
+  
+      // Instance methods from FILEBOX.js
+      toFile(dest: string): Promise<void>;
+    }
+  
+    export class UrlLink {
+      constructor(payload: UrlLinkPayload);
+    }
+  
+    export interface UrlLinkPayload {
+      title: string;
+      desc?: string;
+      linkUrl: string;
+      thumbUrl?: string;
+    }
+  
+    export class MiniApp {
+      constructor(payload: MiniAppPayload);
+    }
+  
+    export interface MiniAppPayload {
+      appid: string;         // miniAppId
+      description?: string;
+      iconUrl?: string;
+      pagePath?: string;
+      thumbKey?: string;
+      thumbUrl?: string;
+      title: string;
+      username: string;      // userName
+    }
+  
+    export class AppMsg {
+      constructor(payload: AppMsgPayload);
+    }
+  
+    export interface AppMsgPayload {
+      appmsg: string;  // 小程序消息的xml字符串
+    }
+  
+    export class Emoji {
+      constructor(payload: EmojiPayload);
+    }
+  
+    export interface EmojiPayload {
+      emojiMd5: string;
+      emojiSize: number;
+    }
+  
+    export class ResponseMsg {
+      revoke(): Promise<void>;  // 消息撤回
+    }
+  
+    export interface GeweEventEmitter {
+      on(event: string, listener: (...args: any[]) => void): this;
+      off(event: string, listener: (...args: any[]) => void): this;
+      emit(event: string, ...args: any[]): boolean;
+    }
+  
+    export type MessageType = keyof MessageStatic["Type"];
+  
+    export interface MessageQueryFilter {
+      id?: string;
+      from?: Contact;
+      to?: Contact;
+      type?: MessageType;
+      room?: Room;
+    }
+  
+    export default GeweBot;
+}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "name": "gewechaty",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "main": "dist/index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "node ./test.js",
     "dev": "npm run build && npm run test",
     "build": "webpack --config ./webpack.config.js",
+    "check-types": "tsc index.d.ts --noEmit",
     "prepublishOnly": "npm run build"
   },
   "author": "MIKO",
@@ -28,15 +30,16 @@
     "node": "20.17.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.25.2",
-    "@babel/preset-env": "^7.25.4",
-    "babel-loader": "^9.2.1",
+    "@swc/core": "^1.10.7",
     "glob": "^11.0.0",
+    "swc-loader": "^0.2.6",
+    "typescript": "^5.4.2",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4"
   },
   "files": [
-    "dist/"
+    "dist/",
+    "index.d.ts"
   ],
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -12,19 +12,19 @@ export {AppMsg} from '@/class/APPMSG.js'
 import {Message} from '@/class/MESSAGE.js'
 import {Room} from '@/class/ROOM.js'
 import { getLocalIPAddress } from "@/utils/index.js";
-import {logout} from '@/action/login.js'
+import {logout, login} from '@/action/login.js'
 import { Friendship } from './class/FRIENDSHIP'
 import {getMyInfo, getMyQrcode, setMyInfo, setPrivacy, setAvatar, getDevices} from '@/action/personal.js'
 import {getAppId, getToken, getUuid} from '@/utils/auth.js'
 import {db} from '@/sql/index.js'
-
+import {cacheAllContact} from '@/action/contact.js'
 
 
 export class GeweBot {
   constructor(option = {}) {
     // 初始化配置
     Object.assign(this, option)
-    const ip = getLocalIPAddress()
+    const ip = option.ip || getLocalIPAddress()
     this.port = this.port || 3000;
     this.static = this.static ||'static';
     this.proxy = this.proxy || `http://${ip}:${this.port}`;
@@ -49,6 +49,10 @@ export class GeweBot {
   }
   on(eventName, callback) {
     bot.on(eventName, callback)
+  }
+  login(){ // return boolean
+    // 登录
+    return login()
   }
   logout(){ // return boolean
     // 退出登录
@@ -82,4 +86,7 @@ export class GeweBot {
     return getDevices()
   }
  
+  async refreshContactCache(){ // 刷新联系人缓存
+    return await cacheAllContact()
+  }
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -37,7 +37,8 @@ app.use(bodyParser());
 
 export const startServe = (option) => {
   // 启动服务
-  let callBackUrl = `http://${ip}:${option.port}${option.route}`
+  var cbip = option.ip || ip;
+  let callBackUrl = `http://${cbip}:${option.port}${option.route}`
   if(option.proxy){
     callBackUrl = `${option.proxy}${option.route}`
   }
@@ -187,7 +188,7 @@ export const startServe = (option) => {
           console.log('服务启动成功')
           resolve({app, router})
         }else{
-          console.log('回调地址设置失败，请确定gewechat能访问到回调地址网络')
+          console.log('回调地址设置失败，请确定gewechat能访问到回调地址网络: ', callBackUrl)
           reject(res)
           process.exit(1);
         }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,19 +23,31 @@ module.exports = {
     },
     extensions: ['.js'],  // 支持导入的文件类型
   },
+  // 添加缓存配置
+  cache: {
+    type: 'filesystem', // 使用文件系统缓存
+    buildDependencies: {
+      config: [__filename], // 构建依赖
+    },
+  },
   module: {
     rules: [
       {
-        test: /\.js$/,  // 匹配所有 JS 文件
+        test: /\.js$/,
         exclude: /node_modules/,
         use: {
-          loader: 'babel-loader',  // 使用 Babel 转译
+          loader: 'swc-loader',
           options: {
-            presets: ['@babel/preset-env'],  // 转译为 ES5 或 ES6+ 兼容的语法
-          },
-        },
-      },
-    ],
+            jsc: {
+              parser: {
+                syntax: "ecmascript"
+              },
+              target: "es2015"
+            }
+          }
+        }
+      }
+    ]
   },
   // optimization: {
   //   splitChunks: {
@@ -54,5 +66,10 @@ module.exports = {
   externals: {
     'better-sqlite3': 'commonjs better-sqlite3',
     'ds': 'commonjs ds'
-  }  
+  },
+  // 添加性能优化配置
+  optimization: {
+    moduleIds: 'deterministic', // 优化模块 ID
+    minimize: true, // 启用压缩
+  }
 };


### PR DESCRIPTION
感谢本项目！
我最近顺利把自己的wechaty项目迁移过来了，根据需要做了部分补充，希望能帮到有需要的人。
1: 增加了index.d.ts以便typescript可以调用--主要是自己的项目使用部分，可能不够全
2: 对旧版本微信群聊信息格式与新版不同做了兼容处理(message增加了roomId).
3: 优化了build过程
4: Bot导出了login() - 以便在被强制退出登录后可以调用
5: refreshContactCache() - 通讯录超过1000时容易超时导致缓存不完整
6: 启动参数增加了ip - 可以通过虚拟网远程连接调试