### PR TITLE
修改默认数据存储目录为 `./data`，并可通过 `data_dir` 选项配置

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,7 @@ declare module 'gewechaty' {
       static?: string;
       route?: string;
       use_cache?: boolean;
+      data_dir?: string;
     }
   
     export interface ContactSelf {

--- a/readme.md
+++ b/readme.md
@@ -353,6 +353,7 @@ const bot = new GeweBot({
   route: "/getWechatCallBack", // 本地回调接口route 默认为 `/getWechatCallBack` 最终地址为 `http://本机ip:port/getWechatCallBack`
   base_api: process.env.WEGE_BASE_API_URL, // 基础api地址base_api 默认为 `http://本机ip:2531/v2/api`
   file_api: process.env.WEGE_FILE_API_URL, // 文件api地址base_api 默认为 `http://本机ip:2532/download`,
+  data_dir: './data', // 数据存储路径 默认为工作目录下的data文件夹
 });
 // 如果docker 和GeweBot在同一台电脑上 可以直接使用 new GeweBot() 即可
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -15,10 +15,11 @@ import { getLocalIPAddress } from "@/utils/index.js";
 import {logout, login} from '@/action/login.js'
 import { Friendship } from './class/FRIENDSHIP'
 import {getMyInfo, getMyQrcode, setMyInfo, setPrivacy, setAvatar, getDevices} from '@/action/personal.js'
-import {getAppId, getToken, getUuid} from '@/utils/auth.js'
+import {createDS, getAppId, getToken, getUuid} from '@/utils/auth.js'
 import {db} from '@/sql/index.js'
 import {cacheAllContact} from '@/action/contact.js'
-
+import { join } from 'node:path';
+import { mkdirSync, existsSync } from 'node:fs'
 
 export class GeweBot {
   constructor(option = {}) {
@@ -33,6 +34,7 @@ export class GeweBot {
     this.route = this.route || '/getWechatCallBack'
     this.use_cache = true
     this.debug = this.debug || false
+    this.data_dir = this.data_dir || join(process.cwd(), 'data')
     // 初始化类
     this.Contact = Contact;
     this.Room = Room
@@ -40,6 +42,13 @@ export class GeweBot {
     this.Message = Message
     this.db = db
     // 初始化事件监听器
+
+    // 初始化数据存储
+    // Create data directory if it doesn't exist
+    if (!existsSync(this.data_dir)) {
+      mkdirSync(this.data_dir, { recursive: true })
+    }
+    createDS(this.data_dir)
   }
   async start(){
     setBaseUrl(this.base_api)

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,11 @@ import {cacheAllContact} from '@/action/contact.js'
 import { join } from 'node:path';
 import { mkdirSync, existsSync } from 'node:fs'
 
+function getDefaultDataPath() {
+  const dsPath = join(process.cwd(), 'ds.json')
+  return existsSync(dsPath) ? process.cwd() : join(process.cwd(), 'data')
+}
+
 export class GeweBot {
   constructor(option = {}) {
     // 初始化配置
@@ -34,7 +39,7 @@ export class GeweBot {
     this.route = this.route || '/getWechatCallBack'
     this.use_cache = true
     this.debug = this.debug || false
-    this.data_dir = this.data_dir || join(process.cwd(), 'data')
+    this.data_dir = this.data_dir || join(process.cwd(), getDefaultDataPath())
     // 初始化类
     this.Contact = Contact;
     this.Room = Room

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -165,9 +165,10 @@ export const startServe = (option) => {
           }
         }
         setCached(true)
-        if(!db.exists(getAppId()+'.db')){
+        const dbPath = join(option.data_dir, getAppId() + '.db')
+        if(!db.exists(dbPath)){
           console.log('创建本地数据库，启用缓存')
-          db.connect(getAppId()+'.db')
+          db.connect(dbPath)
           // 创建表
           db.createContactTable()
           db.createRoomTable()
@@ -177,7 +178,7 @@ export const startServe = (option) => {
           await cacheAllContact()
           console.log('数据初始化完毕')
         }else{
-          db.connect(getAppId()+'.db')
+          db.connect(dbPath)
           console.log('存在缓存数据，启用缓存')
         }
         

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,6 +1,12 @@
 import DS from 'ds';
+import { join } from 'node:path';
 
-let ds = new DS()
+let ds;
+
+export const createDS = (data_dir) => {
+  const ds_path = join(data_dir, 'ds.json')
+  ds = new DS(ds_path)
+}
 
 export const getToken = () => {
   return ds.token || ''


### PR DESCRIPTION
现在数据文件被硬编码在项目根目录，使得数据文件随意堆放，不符合业界“程序与数据分离”的习惯，也不便于运维。

因此，我将默认的数据存储目录改为当前工作目录下的 `data` 目录，且用户可在实例化 `GeweBot` 时通过 `data_dir` 选项配置数据存储的目录，例如：

```typescript
import path from 'node:path';

const bot = new GeweBot({
    // Existing options...
    data_dir: path.join(__dirname, '../data'), // 数据存储路径
});
```

同时，这一更改是与存量的项目兼容的。具体实现方式为：
- 若在实例化 `GeweBot` 时未配置 `data_dir` 选项，会先检查当前工作目录下是否已存在 `ds.json` 文件（存量项目将符合这一条件）。若存在，则直接用当前目录作为数据目录，这样可以与存量项目相兼容
- 而当前目录下不存在  `ds.json` 文件时，意味着不需要做兼容处理，因此将会使用当前工作目录下的 `data` 目录作为缺省数据目录