### PR TITLE
为 sqlite3 库提供兼容层，使 Bun 环境能正常使用本模块

### DIFF
--- a/src/sql/index.js
+++ b/src/sql/index.js
@@ -1,4 +1,4 @@
-import Database from 'better-sqlite3';
+import Database from './sqlite-module';
 import fs from 'fs';
 import {getRoomMemberList} from '@/action/room.js'
 

--- a/src/sql/sqlite-module.js
+++ b/src/sql/sqlite-module.js
@@ -1,0 +1,35 @@
+// 用于根据运行环境选择合适的 SQLite 模块
+let sqliteModule;
+
+// 检查是否在 Bun 运行时环境
+if (typeof Bun !== 'undefined') {
+  sqliteModule = require('bun:sqlite').Database;
+} else {
+  // 否则视为在 Node.js 环境中运行
+  // 获取 Node.js 版本号
+  let nodeVersion = process.version.split('.');
+  nodeVersion[0] = nodeVersion[0].slice(1); // 移除版本号中的 'v' 前缀
+  nodeVersion = nodeVersion.map(item => parseInt(item)); // 将版本号转换为 number[]
+
+  // 检查 Node.js 版本是否大于 22.5.1，
+  // 22.5.1 是第一个稳定支持内置 node:sqlite 模块的版本。
+  // 由于目前版本 (v23.8.0) 的 node:sqlite 仍处在
+  // Stability: 1.1 - Active development 阶段，
+  // 官方文档称不建议在生产环境中使用，
+  // 所以暂时使用 better-sqlite3 模块，
+  // 等待 node:sqlite 模块进入稳定后进行替换。
+  // if (
+  //   nodeVersion[0] > 22 ||
+  //   (nodeVersion[0] === 22 && (
+  //     nodeVersion[1] > 5 ||
+  //     (nodeVersion[1] === 5 && nodeVersion[2] >= 1)
+  //   ))
+  // ) {
+  //   sqliteModule = require('node:sqlite').DatabaseSync;
+  // } else {
+    // 如果是较低版本，使用 better-sqlite3 模块
+    sqliteModule = require('better-sqlite3');
+  // }
+}
+
+export default sqliteModule;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,7 +65,9 @@ module.exports = {
   // },
   externals: {
     'better-sqlite3': 'commonjs better-sqlite3',
-    'ds': 'commonjs ds'
+    'ds': 'commonjs ds',
+    'bun:sqlite': 'commonjs bun:sqlite', // 供 Bun 运行时环境使用，有兼容层
+    // 'node:sqlite': 'commonjs node:sqlite', // 防止旧版本无法打包
   },
   // 添加性能优化配置
   optimization: {


### PR DESCRIPTION
## 现存问题
[Bun](https://bun.sh) 是一个新兴的 JavaScript 运行时，定位为 Node.js 的现代化替代方案。Bun 因为更快的运行速度、原生支持和集成了很多实用功能和工具（例如原生支持 TypeScript / JSX）而愈发受到社区青睐。

然而，当前在 Bun 环境中使用 `gewechaty` 会遇到以下问题，由于 Bun 的底层实现与 Node.js 不同，Bun 无法使用 `better-sqlite3` 模块，因而无法使用 `gewechaty` 模块。然而作为替代，Bun 原生附带了一个性能优于 `better-sqlite3` 的 `bun:sqlite` 模块。

## 解决方案

本 PR 实现了一个**零侵入的兼容层**，新增了 `src/sql/sqlite-module.js` 文件，根据运行环境自动判断，导出对应运行时能够使用的模块。然后将 `src/sql/index.js` 的 `better-sqlite3` 引入语句改为 `./sqlite-module`，以实现向后兼容。

这样一来，本模块无论对 Node.js 还是 Bun 运行时都能很好地支持。

这一更改**不会破坏本模块的向后兼容性**，具体情况如下：

| 特性     | Node.js 运行时 | Bun 运行时 |
|----------|-----------|----------|
| 调用模块 | 用 `better-sqlite3` 模块提供 SQLite 读写能力 | ✅ 利用 Bun 原生库 |
| 现有 API | 无变化 | ✅ 提供兼容层 |
| 安装依赖 | 无变化 | 安装 `better-sqlite3` 但不会实际调用 |