### PR TITLE
修复了 5 处问题

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -316,7 +316,7 @@ declare module 'gewechaty' {
       title: string;
       desc?: string;
       linkUrl: string;
-      thumbUrl?: string;
+      thumbUrl: string;
     }
   
     export class MiniApp {

--- a/index.d.ts
+++ b/index.d.ts
@@ -268,7 +268,9 @@ declare module 'gewechaty' {
         FunctionMsg: 'function_msg',
         NewMonmentTimeline: 'new_monment_timeline',
         ChatHistroy: 'chat_histroy',
+        RoomVoip: 'room_voip',
         Voip: 'voip',
+        VoipHangup: 'voip_hangup',
         RealTimeLocation: 'real_time_location',
       };
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -83,21 +83,32 @@ declare module 'gewechaty' {
   
     export class Contact {
       // Properties from CONTACT.js constructor
+      /** @deprecated 不建议直接访问私有变量，可使用 `name()` 方法替代 */
       _name: string;
+      /** @deprecated 不建议直接访问私有变量，可使用 `alias()` 方法替代 */
       _alias: string;
+      /** @deprecated 不建议直接访问私有变量，可使用 `friend()` 方法替代 */
       _isFriend: boolean;
+      /** @deprecated 不建议直接访问私有变量，可使用 `wxid()` 方法替代 */
       _wxid: string | null;
+      /** @deprecated 不建议直接访问私有变量，可使用 `type()` 方法替代 */
       _type: number;
+      /** @deprecated 不建议直接访问私有变量，可使用 `gender()` 方法替代 */
       _gender: number;
+      /** @deprecated 不建议直接访问私有变量，可使用 `province()` 方法替代 */
       _province: string | null;
+      /** @deprecated 不建议直接访问私有变量，可使用 `city()` 方法替代 */
       _city: string | null;
+      /** @deprecated 不建议直接访问私有变量，可使用 `avatar()` 方法替代 */
       _avatarUrl: string;
+      /** @deprecated 不建议直接访问私有变量，可使用 `self()` 方法替代 */
       _isSelf: boolean;
       inviterUserName: string;
-  
+      
       // Methods from CONTACT.js
       say(textOrContactOrFileOrUrl: string | Contact | Filebox | UrlLink | MiniApp): Promise<ResponseMsg>;
       name(): string;
+      wxid(): string;
       alias(newAlias?: string): Promise<string | void>;
       friend(): boolean;
       type(): number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -159,8 +159,8 @@ declare module 'gewechaty' {
       // Methods from ROOM.js
       sync(): Promise<Room>;
       say(textOrContactOrFileOrUrl: string | Contact | Filebox | UrlLink | MiniApp, ats?: Contact[] | '@all'): Promise<ResponseMsg>;
-      on(event: 'join', listener: (room: Room, inviteeList: Contact[], inviter: Contact) => void): void;
-      on(event: 'leave', listener: (room: Room, leaverList: Contact[], remover?: Contact) => void): void;
+      on(event: 'join', listener: (room: Room, invitee: Contact, inviter: Contact) => void): void;
+      on(event: 'leave', listener: (room: Room, leaver: Contact, remover?: Contact) => void): void;
       on(event: 'topic', listener: (room: Room, newTopic: string, oldTopic: string, changer: Contact) => void): void;
       add(contact: Contact | string, reason?: string): Promise<void>;
       del(contact: Contact | string): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -108,7 +108,7 @@ declare module 'gewechaty' {
       // Methods from CONTACT.js
       say(textOrContactOrFileOrUrl: string | Contact | Filebox | UrlLink | MiniApp): Promise<ResponseMsg>;
       name(): string;
-      wxid(): string;
+      wxid(): string | null;
       alias(newAlias?: string): Promise<string | void>;
       friend(): boolean;
       type(): number;
@@ -120,19 +120,67 @@ declare module 'gewechaty' {
       self(): boolean;
   
       // Static methods
-      static find(query: ContactQueryFilter): Promise<Contact | undefined>;
-      static findAll(query: ContactQueryFilter): Promise<Contact[]>;
+      /**
+       * 根据名称、别名或微信 ID 精确查询单个联系人
+       * @param {string|Object} query - 查询条件，可以是字符串或查询对象：
+       *   - 若为字符串，将按微信 ID 精确查询
+       *   - 若为对象，需包含以下属性之一：
+       *     @property {string} [name] - 联系人名称（精确匹配）
+       *     @property {string} [alias] - 联系人备注名（精确匹配）
+       *     @property {string} [wxid] - 联系人微信 ID（精确匹配）
+       * @returns {Promise<Contact|null>} 返回 Promise，解析为匹配的联系人对象，未找到返回 null
+       * @throws {Error} 当参数格式不符合要求或未提供有效查询条件时抛出
+       */
+      static find(query: string | ContactQueryFilter): Promise<Contact | null>;
+      /**
+       * 批量查询联系人，支持模糊匹配或获取全部
+       * @param {Object} [query] - 可选查询条件对象：
+       *   - 不传参数时返回所有联系人
+       *   - 若传对象，需包含以下属性之一：
+       *     @property {string} [name] - 联系人名称（模糊匹配）
+       *     @property {string} [alias] - 联系人备注名（模糊匹配）
+       * @returns {Promise<Contact[]>} 返回 Promise，解析为联系人数组，无匹配条目时返回空数组
+       * @throws {Error} 当参数格式不符合要求或查询条件不合法时抛出
+       */
+      static findAll(query?: ContactQueryAllFilter): Promise<Contact[]>;
     }
   
     export interface ContactStatic {
-      find(query: ContactQueryFilter): Promise<Contact | undefined>;
-      findAll(query: ContactQueryFilter): Promise<Contact[]>;
+      // Static methods
+      /**
+       * 根据名称、别名或微信 ID 精确查询单个联系人
+       * @param {string|Object} query - 查询条件，可以是字符串或查询对象：
+       *   - 若为字符串，将按微信 ID 精确查询
+       *   - 若为对象，需包含以下属性之一：
+       *     @property {string} [name] - 联系人名称（精确匹配）
+       *     @property {string} [alias] - 联系人备注名（精确匹配）
+       *     @property {string} [wxid] - 联系人微信 ID（精确匹配）
+       * @returns {Promise<Contact|null>} 返回 Promise，解析为匹配的联系人对象，未找到返回 null
+       * @throws {Error} 当参数格式不符合要求或未提供有效查询条件时抛出
+       */
+      find(query: string | ContactQueryFilter): Promise<Contact | null>;
+      /**
+       * 批量查询联系人，支持模糊匹配或获取全部
+       * @param {Object} [query] - 可选查询条件对象：
+       *   - 不传参数时返回所有联系人
+       *   - 若传对象，需包含以下属性之一：
+       *     @property {string} [name] - 联系人名称（模糊匹配）
+       *     @property {string} [alias] - 联系人备注名（模糊匹配）
+       * @returns {Promise<Contact[]>} 返回 Promise，解析为联系人数组，无匹配条目时返回空数组
+       * @throws {Error} 当参数格式不符合要求或查询条件不合法时抛出
+       */
+      findAll(query?: ContactQueryAllFilter): Promise<Contact[]>;
     }
   
     export interface ContactQueryFilter {
       name?: string;
       alias?: string;
-      id?: string;
+      wxid?: string;
+    }
+
+    export interface ContactQueryAllFilter {
+      name?: string;
+      alias?: string;
     }
   
     export class Friendship {

--- a/readme.md
+++ b/readme.md
@@ -186,7 +186,7 @@ bot
       room.on('join', async (room, contact) => {
         const urlLink = new UrlLink({
           title: `${contact.name()}加入了群聊`,
-          desc: `微信号：${contact._wxid}`,
+          desc: `微信号：${contact.wxid()}`,
           linkUrl: 'https://www.example.com',
           thumbUrl: `${bot.proxy}/example/avatar.jpg`
         })
@@ -194,8 +194,8 @@ bot
       })
       room.on('leave', async (room, contact) => {
         const urlLink = new UrlLink({
-          title: `${contact._name}退出了群聊`,
-          desc: `微信号：${contact._wxid}`,
+          title: `${contact.name()}退出了群聊`,
+          desc: `微信号：${contact.wxid()}`,
           linkUrl: 'https://www.example.com',
           thumbUrl: `${bot.proxy}/example/avatar.jpg`
         })

--- a/readme.md
+++ b/readme.md
@@ -491,6 +491,7 @@ const bot = new GeweBot({
 | `Revoke`         | 撤回消息     |
 | `Pat`            | 拍一拍       |
 | `Location`       | 位置消息     |
+| 更多请参阅 `.d.ts` 的 `MessageStatic.type`|
 
 ### Friendship 类方法表
 

--- a/readme.md
+++ b/readme.md
@@ -185,9 +185,10 @@ bot
     if(room){
       room.on('join', async (room, contact) => {
         const urlLink = new UrlLink({
-          title: `${contact._name}加入了群聊`,
+          title: `${contact.name()}加入了群聊`,
           desc: `微信号：${contact._wxid}`,
-          linkUrl: 'https://www.baidu.com'
+          linkUrl: 'https://www.example.com',
+          thumbUrl: `${bot.proxy}/example/avatar.jpg`
         })
         room.say(urlLink)
       })
@@ -195,7 +196,8 @@ bot
         const urlLink = new UrlLink({
           title: `${contact._name}退出了群聊`,
           desc: `微信号：${contact._wxid}`,
-          linkUrl: 'https://www.baidu.com'
+          linkUrl: 'https://www.example.com',
+          thumbUrl: `${bot.proxy}/example/avatar.jpg`
         })
         room.say(urlLink)
       })
@@ -258,7 +260,7 @@ const onMessage = async (msg) => {
     title: "测试链接",
     desc: "测试链接",
     thumbUrl: `${bot.proxy}/test/avatar.jpg`,
-    linkUrl: "https://www.baidu.com",
+    linkUrl: "https://www.example.com",
   });
   await msg.say(urlLink);
 

--- a/src/action/contact.js
+++ b/src/action/contact.js
@@ -50,22 +50,24 @@ export const contactSync = async (wxid) => {
 }
 
 
+/**
+ * 根据名称、别名或微信 ID 精确查询单个联系人
+ * @param {string|Object} query - 查询条件，可以是字符串或查询对象：
+ *   - 若为字符串，将按微信 ID 精确查询
+ *   - 若为对象，需包含以下属性之一：
+ *     @property {string} [name] - 联系人名称（精确匹配）
+ *     @property {string} [alias] - 联系人备注名（精确匹配）
+ *     @property {string} [wxid] - 联系人微信 ID（精确匹配）
+ * @returns {Promise<Contact|null>} 返回 Promise，解析为匹配的联系人对象，未找到返回 null
+ * @throws {Error} 当参数格式不符合要求或未提供有效查询条件时抛出
+ */
 export const find = async (content) => { // 使用name alias wxid查询
-  let contactsInfo = ''
-  if(typeof content === 'string'){
-    contactsInfo = content
-
-  }else if(typeof content ==='object'){
-    contactsInfo = content.name || content.alias || content.id
-  }else{
-    console.log('不支持的查询内容')
-    return null
+  if(
+    !(typeof content === 'string' && content.length > 0) ||
+    typeof content ==='object'
+  ){
+    throw new Error('不支持的查询内容')
   }
-  if(!contactsInfo){
-    console.log('查询内容不能为空')
-    return null
-  }
-
 
   let contact = null
   if(typeof content ==='string'){
@@ -75,18 +77,28 @@ export const find = async (content) => { // 使用name alias wxid查询
       contact = db.findOneByName(content.name)
     }else if(content.alias){
       contact = db.findOneByAlias(content.alias)
-    }else if(content.id){
+    }else if(content.id){ // 兼容旧代码，现已规范化为wxid
       contact = db.findOneByWxId(content.id)
+    }else if(content.wxid){
+      contact = db.findOneByWxId(content.wxid)
     }else{
-      console.log('不支持的查询内容')
-      return null
+      throw new Error('至少需要一个查询条件')
     }
   }
   return contact? new Contact(contact) : null
 }
 
+/**
+ * 批量查询联系人，支持模糊匹配或获取全部
+ * @param {Object} [query] - 可选查询条件对象：
+ *   - 不传参数时返回所有联系人
+ *   - 若传对象，需包含以下属性之一：
+ *     @property {string} [name] - 联系人名称（模糊匹配）
+ *     @property {string} [alias] - 联系人备注名（模糊匹配）
+ * @returns {Promise<Contact[]>} 返回 Promise，解析为联系人数组，无匹配条目时返回空数组
+ * @throws {Error} 当参数格式不符合要求或查询条件不合法时抛出
+ */
 export const findAll = async (query) => {
-  let arr = []
   let rows = []
   if(!query){
     rows = db.findAllContacts()
@@ -96,13 +108,12 @@ export const findAll = async (query) => {
     }else if(query.alias){
       rows = db.findAllByAlias(query.alias)
     }else{
-      console.log('不支持的查询内容')
-      return arr
+      throw new Error('至少需要一个查询条件')
     }
+  }else{
+    throw new Error('不支持的查询内容')
   }
-  rows.map(item => {
-    arr.push(new Contact(item))
-  })
+  const arr = rows.map(item => new Contact(item))
   return arr
 }
 

--- a/src/class/CONTACT.js
+++ b/src/class/CONTACT.js
@@ -28,6 +28,10 @@ export class Contact {
     return this._name;
   }
 
+  wxid() {
+    return this._wxid;
+  }
+
   async alias(newAlias) {
     if(newAlias){
       return await setRemark(this._wxid, newAlias)

--- a/src/class/CONTACT.js
+++ b/src/class/CONTACT.js
@@ -76,11 +76,31 @@ export class Contact {
   }
 
   // 静态方法
-
+  /**
+   * 根据名称、别名或微信 ID 精确查询单个联系人
+   * @param {string|Object} query - 查询条件，可以是字符串或查询对象：
+   *   - 若为字符串，将按微信 ID 精确查询
+   *   - 若为对象，需包含以下属性之一：
+   *     @property {string} [name] - 联系人名称（精确匹配）
+   *     @property {string} [alias] - 联系人备注名（精确匹配）
+   *     @property {string} [wxid] - 联系人微信 ID（精确匹配）
+   * @returns {Promise<Contact|null>} 返回 Promise，解析为匹配的联系人对象，未找到返回 null
+   * @throws {Error} 当参数格式不符合要求或未提供有效查询条件时抛出
+   */
   static async find(query) {
     return find(query)
   }
 
+  /**
+   * 批量查询联系人，支持模糊匹配或获取全部
+   * @param {Object} [query] - 可选查询条件对象：
+   *   - 不传参数时返回所有联系人
+   *   - 若传对象，需包含以下属性之一：
+   *     @property {string} [name] - 联系人名称（模糊匹配）
+   *     @property {string} [alias] - 联系人备注名（模糊匹配）
+   * @returns {Promise<Contact[]>} 返回 Promise，解析为联系人数组，无匹配条目时返回空数组
+   * @throws {Error} 当参数格式不符合要求或查询条件不合法时抛出
+   */
   static async findAll(query) {
     return findAll(query)
   }

--- a/src/class/MESSAGE.js
+++ b/src/class/MESSAGE.js
@@ -191,34 +191,26 @@ export class Message {
       switch (type) {
         case 1:
           return MessageType.Text;
-          break;
         case 3:
           return MessageType.Image;
-          break;
         case 34:
           return MessageType.Voice;
-          break;
         case 37:
           return MessageType.AddFriend;
-          break;
         case 42:
           return MessageType.Contact;
-          break;
         case 43:
           return MessageType.Video;
-          break;
         case 47:
           return MessageType.Emoji;
-          break;
         case 48:
           return MessageType.Location
-          break;
         case 49:
           jObj = Message.getXmlToJson(xml);
           // console.log(jObj)
           if (jObj.msg.appmsg.type === 5) {
             if (jObj.msg.appmsg.title === '邀请你加入群聊') {
-              return MessageType.RoomInvitation
+              return MessageType.RoomInvitation;
             } else { // 公众号链接
               return MessageType.Link;
             }
@@ -243,8 +235,7 @@ export class Message {
           }
           break;
         case 50:
-          //VOIP挂断
-          break;
+          return MessageType.VoipHangup; // 微信电话挂断
         case 51:
           //状态通知
           jObj = Message.getXmlToJson(xml);
@@ -255,32 +246,34 @@ export class Message {
           }
           break;
         case 56:
-          //语音群聊
-          break;
+          return MessageType.RoomVoip; // 群语音
         case 10000:
           //群通知
           break;
         case 10002:
           jObj = Message.getXmlToJson(xml);
           if (jObj.sysmsg.type === 'revokemsg') {
-            return MessageType.Revoke
+            return MessageType.Revoke;
           } else if (jObj.sysmsg.type === 'pat') {
-            return MessageType.Pat
+            return MessageType.Pat;
           } else if (jObj.sysmsg.type === 'functionmsg') {
-            return MessageType.FunctionMsg
+            return MessageType.FunctionMsg;
           } else if (jObj.sysmsg.type === 'ilinkvoip') {
-            //voip邀请
-            return MessageType.Voip
+            // voip邀请
+            return MessageType.Voip;
           } else if (jObj.sysmsg.type === 'trackmsg') {
-            //实时位置更新
+            // 实时位置更新
           }
           break;
-        default:
-          return MessageType.Unknown
       }
     } catch (e) {
-      return MessageType.Unknown
+      // Do nothing
     }
+
+    // 不管是因为报错，还是未被任何 case 匹配，
+    // 还是匹配了之后因未处理而 break 下来，都需要返回未知类型，
+    // 以避免返回 undefined 的情况
+    return MessageType.Unknown;
   }
   static revoke (obj) {
     return revoke(obj)

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ export {Voice} from '@/class/VOICE.js'
 export {Emoji} from '@/class/EMOJI.js'
 export {MiniApp} from '@/class/MINIAPP.js'
 export {AppMsg} from '@/class/APPMSG.js'
+export {Contact} from '@/class/CONTACT.js'
 import {Message} from '@/class/MESSAGE.js'
 import {Room} from '@/class/ROOM.js'
 import { getLocalIPAddress } from "@/utils/index.js";

--- a/src/type/MessageType.js
+++ b/src/type/MessageType.js
@@ -1,31 +1,33 @@
 import { Voice } from "@/class/VOICE";
 
 export const MessageType = {
-  Unknown: 'unknown', // 未知类型
-  FileStart: 'file_start', // 文件开始
-  File: 'file', // 文件发送结束
-  Voice: 'voice', // 语音
-  Contact: 'contact', // 名片
-  Emoji: 'emoji', // 表情
-  Image: 'image', // 图片
-  Text: 'text', // 文本
-  Video: 'video', // 视频
-  Url: 'link', // 链接
-  RoomInvitation: 'room_invitation', // 群邀请
-  MiniApp:'mini_app', // 小程序消息
-  AppMsg: 'app_msg', // app消息
-  Link: 'link', // 公众号链接
-  AddFriend: 'add_friend', // 添加好友通知
-  Quote: 'quote', // 引用消息
-  Transfer: 'transfer', //转账
-  RedPacket: 'red_packet', //红包
-  VideoAccount: 'video_account', // 视频号消息
-  Revoke: 'revoke', // 撤回消息
-  Pat:'pat', // 拍一拍
-  Location: 'location', // 位置消息
-  FunctionMsg: 'function_msg', // 微信团队消息
-  NewMonmentTimeline: 'new_monment_timeline', // 朋友圈更新
-  ChatHistroy: 'chat_histroy', // 聊天记录
-  Voip: 'voip', // voip消息
-  RealTimeLocation: 'real_time_location', // 实时位置共享
+  Unknown: 'unknown',                           // 未知类型
+  FileStart: 'file_start',                      // 文件开始
+  File: 'file',                                 // 文件发送结束
+  Voice: 'voice',                               // 语音
+  Contact: 'contact',                           // 名片
+  Emoji: 'emoji',                               // 表情
+  Image: 'image',                               // 图片
+  Text: 'text',                                 // 文本
+  Video: 'video',                               // 视频
+  Url: 'link',                                  // 链接
+  RoomInvitation: 'room_invitation',            // 群邀请
+  MiniApp:'mini_app',                           // 小程序消息
+  AppMsg: 'app_msg',                            // app消息
+  Link: 'link',                                 // 公众号链接
+  AddFriend: 'add_friend',                      // 添加好友通知
+  Quote: 'quote',                               // 引用消息
+  Transfer: 'transfer',                         // 转账
+  RedPacket: 'red_packet',                      // 红包
+  VideoAccount: 'video_account',                // 视频号消息
+  Revoke: 'revoke',                             // 撤回消息
+  Pat:'pat',                                    // 拍一拍
+  Location: 'location',                         // 位置消息
+  FunctionMsg: 'function_msg',                  // 微信团队消息
+  NewMonmentTimeline: 'new_monment_timeline',   // 朋友圈更新
+  ChatHistroy: 'chat_histroy',                  // 聊天记录
+  RoomVoip: 'room_voip',                        // 群语音
+  Voip: 'voip',                                 // voip消息
+  VoipHangup: 'voip_hangup',                    // voip挂断
+  RealTimeLocation: 'real_time_location',       // 实时位置共享
 };


### PR DESCRIPTION
不行了，我必须放下书面用语狠狠吐槽一下，这个模块到处都是坑，差不多算买 bug 送模块了……

由于这些修复可能存在关联性，或者都是一个地方看到的，我最终合并到一起 PR。

## 类型声明和文档错误：构造 `UrlLink` 类时的 `thumbUrl` 参数被错误地标为可选

### 现存问题

根据现有逻辑，对 `UrlLink` 类进行实例化时，如果没有传入 `thumbUrl` 参数，会抛出错误：

``` Typescript
export class UrlLink {
  constructor(obj) {
    // ...
    // 对 thumbUrl 进行空值判断
    if (!obj.thumbUrl) {
      throw new Error('thumbUrl 字段不能为空');
    }
    // ...
```

然而，无论是 `.d.ts` 中的类型声明，还是 README 中的示例代码，都认为这是可选的。这会带来意外的程序 panic。

> 吐槽：这可是主页中的示例代码，但运行会居然引发致命错误……

### 解决方案

本 PR 做了如下修改：
- 修正 `.d.ts` 文件，定义 `thumbUrl` 为必选参数
- 更新 `readme.md` 文件中的示例代码，当前示例中有几处缺少这一参数
- 顺带更改了实例代码中的 `baidu.com` 为 `example.com`，以避免潜在的问题

## 类型声明错误：`Room.prototype.on` 的 `join`/`leave` 事件参数名称和类型有误

### 现存问题

根据程序逻辑和实际测试，这两个事件的原 inviteeList / leaverList 参数，应为 Contact 类型。即使一次性添加或移除多个联系人，也只会连续收到多条消息，每条都是 Contact 类型。原类型 Contact[] 与实际实现不符。

### 解决方案

本 PR 修正了 `.d.ts` 文件，将这两个事件的参数名称改为 invitee / leaver，类型修正为 Contact。

## 逻辑错误：`Message.prototype.type()` 有概率返回 `undefined`

### 现存问题

根据类型声明和逻辑思路，`Message.prototype.type()` 方法预期的返回值应当限于 `src/type/MessageType.js` 中的消息类型，未识别或者未处理的消息类型应当返回 `MessageType.Unknown`。

但在实际逻辑 `switch` 部分的多个分支中，错误地直接用 `break` 跳出，而后方也没有用于兜底的 `return MessageType.Unknown` 语句。这就导致了这些用 `break` 跳出的分支会直接返回 `undefined`。

另外，README 中列出的 `MessageType 类型表` 中缺少了不少类型。

> 吐槽：难评，返回 undefined 搞得我依赖此模块开发的时候，插入 SQL 崩溃好几次……

### 解决方案

本 PR 重新整理了 `src/class/MESSAGE.js` 中 `static getType()` 函数，即 `Message.prototype.type()` 调用的实际函数的逻辑，最终所有出错的、未被任何 case 匹配的、未被处理而 break 的分支，都将走到程序底部，执行兜底语句 `return MessageType.Unknown` 返回未知类型。

还顺手添加了两个类型。然后在 README 里面开了个摆，因为懒得一个个类型补充了，反正前面的开发者也不补充。

有心之士可以用 AI 生成或者人工补充一下。

## 不符合最佳实践：`Contact` 类常常甚至有时候必须外部访问私有变量

### 现存问题

由于本模块最初的设计问题，私有变量大量被外部访问。即使是 README 中的示例代码，也多处用到了私有变量。甚至于，常用的用于获取联系人微信 ID 的方式，只有私有变量 `Contact.prototype._wxid` 一种。这样将私有变量暴露在外，既不符合业界最佳实践，也容易遭到预期外的更改，导致预期外的行为。

### 解决方案

本 PR 做了以下改动：
- 提供了 `wxid()` 方法来查询联系人的微信 ID
- 在 `.d.ts` 类型定义中，标记所有 `Contact` 类的私有对象为弃用
- 对应修改了 README 示例代码中涉及私有变量的调用

这些更改是向后兼容的。

### 后续建议

由于考虑向后兼容性考虑，本 PR 还是保留了这些私有变量的可访问性，只是提供了替代方法，并在声明中标记弃用。

建议在后续版本中，彻底将这些方法转为真正私有（`#` 私有变量从老黄历的 Node 12.0.0 起就支持了，几乎没有兼容性问题），或至少在 `.d.ts` 中删除。

另外，`Message` 类也有这个问题，但那个逻辑比这个复杂，改不动了。

## 导出和类型声明问题：`Contract` 类居然没有被模块导出，静态方法逻辑混乱

### 现存问题

这个我是真无语……想用 `Contact` 类根据微信 ID 新建联系人，却告诉我方法不存在。找了半天没找到问题（即使 Typescript 也不会报错，因为类型声明里声明了导出），天猜得到是因为这个类实际根本就没导出啊？

另外，这个类的两个静态方法问题也不小，一方面类型导出与实际不符，另一方面实现的逻辑也很乱。原本逻辑不细讲了，不知道从何讲起。

### 解决方案

本 PR 做了以下修改：
- 修改了 `src/index.js`，导出了 `Contact` 类
- 修改了 `src/action/contact.js`，重构了两个静态方法，本来逻辑好乱
- 在上面方法中、`src/class/CONTACT.js` 中，还有 `.d.ts` 中都加上了 JSDoc
- 相应修改了 `.d.ts` 中的错误标注

这一改动可能有潜在的不兼容问题——在有人把 bug 当特性的情况下。不考虑这种情况的话，本修改向后兼容。