### PR TITLE
完善了几处类型定义，并微调了几处有问题的逻辑

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,9 @@
+import { type MyDB } from './src/sql/index.d';
+
 declare module 'gewechaty' {
     export class GeweBot {
       constructor(options?: GeweBotOptions);
-      db: any; // SQLite database instance
+      db: MyDB; // SQLite database instance
       use_cache: boolean;
       start(): Promise<{
         app: import('koa');

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,6 @@
 import { type MyDB, type RoomMemberInDB } from './src/sql/index.d';
+import type Koa from 'koa';
+import type Router from 'koa-router';
 
 declare module 'gewechaty' {
     export class GeweBot {
@@ -6,8 +8,8 @@ declare module 'gewechaty' {
       db: MyDB; // SQLite database instance
       use_cache: boolean;
       start(): Promise<{
-        app: import('koa');
-        router: import('koa-router');
+          app: Koa;
+          router: Router;
       }>;
       on(event: 'message', listener: (msg: Message) => void): void;
       on(event: 'friendship', listener: (friendship: Friendship) => void): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { type MyDB } from './src/sql/index.d';
+import { type MyDB, type RoomMemberInDB } from './src/sql/index.d';
 
 declare module 'gewechaty' {
     export class GeweBot {
@@ -215,7 +215,7 @@ declare module 'gewechaty' {
       isNotify: boolean;
       OwnerId: string;
       avatarImg: string;
-      memberList: any[];
+      memberList: RoomMemberInDB;
   
       // Methods from ROOM.js
       sync(): Promise<Room>;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
   },
   "devDependencies": {
     "@swc/core": "^1.10.7",
+    "@types/better-sqlite3": "^7.6.12",
+    "@types/bun": "^1.2.3",
     "glob": "^11.0.0",
     "swc-loader": "^0.2.6",
     "typescript": "^5.4.2",
@@ -39,6 +41,7 @@
   },
   "files": [
     "dist/",
+    "src/**/*.d.ts",
     "index.d.ts"
   ],
   "repository": {

--- a/src/class/ROOM.js
+++ b/src/class/ROOM.js
@@ -97,17 +97,17 @@ export class Room {
     if(memberList.length === 0){
       return []
     }
+
     if(!query){
       return memberList.map(item => {
         return new Contact(item)
       })
     }
-    const arr = []
-    memberList.map(item => {
-      if(item.nickName === query || item.displayName === query){
-        arr.push(new Contact(item)) 
-      }
-    })
+
+    const arr = memberList.filter(item => 
+      item.nickName === query || item.displayName === query
+    ).map(item => new Contact(item))
+
     return arr
   }
 

--- a/src/sql/index.d.ts
+++ b/src/sql/index.d.ts
@@ -1,0 +1,137 @@
+import { type Database as DatabaseSqlite3 } from 'better-sqlite3';
+import { type Database as DatabaseBun } from 'bun:sqlite';
+
+/** 群成员的接口定义 */
+export declare interface RoomMemberInDB {
+  /** 用户唯一标识 */
+  wxid: string;
+  /** 用户昵称 */
+  nickName: string;
+  /** 邀请者用户名，可能为 null */
+  inviterUserName: string | null;
+  /** 成员标志 */
+  memberFlag: number;
+  /** 疑似为群昵称？可能为 null */
+  displayName: string | null;
+  /** 大头像 URL */
+  bigHeadImgUrl: string;
+  /** 小头像 URL */
+  smallHeadImgUrl: string;
+}
+
+/** 联系人的接口定义 */
+declare interface ContactInDb {
+  userName: string | null;
+  nickName: string | null;
+  pyInitial: string | null;
+  quanPin: string | null;
+  sex: number | null;
+  remark: string | null;
+  remarkPyInitial: string | null;
+  remarkQuanPin: string | null;
+  signature: string | null;
+  alias: string | null;
+  snsBgImg: string | null;
+  country: string | null;
+  bigHeadImgUrl: string | null;
+  smallHeadImgUrl: string | null;
+  description: string | null;
+  cardImgUrl: string | null;
+  labelList: string | null;
+  province: string | null;
+  city: string | null;
+  phoneNumList: string | null;
+}
+
+/** 联系人的接口定义，所有字段为可选的 */
+declare interface ContactInDbOptional {
+  userName: string | undefined;
+  nickName: string | undefined;
+  pyInitial: string | undefined;
+  quanPin: string | undefined;
+  sex: number | undefined;
+  remark: string | undefined;
+  remarkPyInitial: string | undefined;
+  remarkQuanPin: string | undefined;
+  signature: string | undefined;
+  alias: string | undefined;
+  snsBgImg: string | undefined;
+  country: string | undefined;
+  bigHeadImgUrl: string | undefined;
+  smallHeadImgUrl: string | undefined;
+  description: string | undefined;
+  cardImgUrl: string | undefined;
+  labelList: string | undefined;
+  province: string | undefined;
+  city: string | undefined;
+  phoneNumList: string | undefined;
+}
+
+/** 群聊的接口定义 */
+declare interface RoomInDb {
+  chatroomId: string | null;
+  nickName: string | null;
+  pyInitial: string | null;
+  quanPin: string | null;
+  sex: number | null;
+  remark: string | null;
+  remarkPyInitial: string | null;
+  remarkQuanPin: string | null;
+  chatRoomNotify: number | null;
+  chatRoomOwner: string | null;
+  smallHeadImgUrl: string | null;
+  memberList: RoomMemberInDB[] | null; // 已解析为对象数组
+}
+
+export declare class MyDB {
+  db: DatabaseSqlite3 | DatabaseBun | null;
+
+  constructor();
+
+  /** 检查数据库是否存在 */
+  exists(dbName: string): boolean;
+  /** 传入数据库名称，检查是否存在数据库，存在则返回 db 实例，不存在则创建并返回实例 */
+  connect(dbName: string): DatabaseSqlite3 | DatabaseBun;
+  /** 尝试创建contact表，如果该表已存在则不生效 */
+  createContactTable(): void;
+  /** 尝试创建room表，如果该表已存在则不生效 */
+  createRoomTable(): void;
+
+  /** 根据 wxid 查找联系人，返回该条数据或 null */
+  findOneByWxId(wxid: string): ContactInDb | null;
+  /** 根据昵称查找联系人，返回该条数据或 null */
+  findOneByName(nickName: string): ContactInDb | null;
+  /** 根据昵称查找全部符合条件的联系人，返回数据数组或空数组 */
+  findAllByName(nickName: string): ContactInDb[];
+  /** 根据微信备注查找联系人，返回该条数据或 null */
+  findOneByAlias(alias: string): ContactInDb | null;
+  /** 根据微信备注查找全部符合条件的联系人，返回数据数组或空数组 */
+  findAllByAlias(alias: string): ContactInDb[];
+
+  /** 根据 chatroomId 查找群聊，返回该条数据或 null */
+  findOneByChatroomId(chatroomId: string): RoomInDb | null;
+  /** 根据群聊名称查找群聊，返回该条数据或 null */
+  findOneByChatroomName(name: string): RoomInDb | null;
+  /** 根据群聊名称查找全部符合条件的群聊，返回数据数组或空数组 */
+  findAllByChatroomName(name: string): RoomInDb[];
+
+  /** 更新 room 表中的 memberList 字段，返回成功更改的记录数量 */
+  updateRoomMemberList(chatroomId: string, memberList: RoomMemberInDB[]): number;
+
+  /** 插入新的联系人数据，如果存在则更新，返回成功更改的记录数量 */
+  insertContact(contact: ContactInDbOptional): number;
+  /** 插入新的群聊数据，如果存在则更新，返回成功更改的记录数量 */
+  insertRoom(room: RoomInDb): number;
+
+  /** 更新联系人数据，返回成功更改的记录数量 */
+  updateContact(userName: string, newData: Partial<ContactInDbOptional>): number;
+  /** 更新群聊数据，返回成功更改的记录数量 */
+  updateRoom(chatroomId: string, newData: Partial<RoomInDb>): Promise<number>;
+
+  /** 查询所有联系人数据 */
+  findAllContacts(): ContactInDb[];
+  /** 查询所有群聊数据 */
+  findAllRooms(): RoomInDb[];
+}
+
+export const db: MyDB;

--- a/src/sql/index.js
+++ b/src/sql/index.js
@@ -2,16 +2,17 @@ import Database from './sqlite-module';
 import fs from 'fs';
 import {getRoomMemberList} from '@/action/room.js'
 
-class myDB {
+class MyDB {
   constructor() {
     this.db = null;
   }
 
+  /** 检查数据库是否存在 */
   exists(dbName) {
     return fs.existsSync(dbName);
   }
 
-  // 方法1：传入数据库名称，检查是否存在数据库，存在则返回db实例，不存在则创建并返回实例
+  /** 传入数据库名称，检查是否存在数据库，存在则返回db实例，不存在则创建并返回实例 */
   connect(dbName) {
     if (!fs.existsSync(dbName)) {
       console.log(`Database ${dbName} does not exist, creating...`);
@@ -21,7 +22,7 @@ class myDB {
     return this.db;
   }
 
-  // 方法2：创建contact表，如果不存在则创建
+  /** 尝试创建contact表，如果该表已存在则不生效 */
   createContactTable() {
     const tableName = 'contact';
     const tableSchema = `
@@ -56,7 +57,7 @@ class myDB {
     }
   }
 
-  // 方法2：创建room表，如果不存在则创建
+  /** 尝试创建room表，如果该表已存在则不生效 */
   createRoomTable() {
     const tableName = 'room';
     const tableSchema = `
@@ -91,59 +92,60 @@ class myDB {
     }
   }
 
-  // 方法3：根据 userName 查找联系人，返回该条数据或 null
+  /** 根据 wxid 查找联系人，返回该条数据或 null */
   findOneByWxId(wxid) {
     const stmt = this.db.prepare('SELECT * FROM contact WHERE userName = ?');
     const row = stmt.get(wxid);
     return row ? row : null;
   }
-
+  /** 根据昵称查找联系人，返回该条数据或 null */
   findOneByName(nickName) {
     const stmt = this.db.prepare('SELECT * FROM contact WHERE nickName = ?');
     const row = stmt.get(nickName);
     return row ? row : null;
   }
+  /** 根据昵称查找全部符合条件的联系人，返回数据数组或空数组 */
   findAllByName(nickName) {
     const stmt = this.db.prepare('SELECT * FROM contact WHERE nickName = ?');
     const rows = stmt.all(nickName);
-    return rows.length > 0 ? rows : null;
+    return rows; // 当没有匹配的记录时，会返回空数组
   }
-
+  /** 根据微信备注查找联系人，返回该条数据或 null */
   findOneByAlias(alias) {
     const stmt = this.db.prepare('SELECT * FROM contact WHERE remark = ?');
     const row = stmt.get(alias);
     return row ? row : null;
   }
-
+  /** 根据微信备注查找全部符合条件的联系人，返回数据数组或空数组 */
   findAllByAlias(alias) {
     const stmt = this.db.prepare('SELECT * FROM contact WHERE remark = ?');
     const rows = stmt.all(alias);
-    return rows.length > 0 ? rows : null;
+    return rows; // 当没有匹配的记录时，会返回空数组
   }
 
-  // 方法3：根据 chatroomId 查找房间，返回该条数据或 null
+  /** 根据 chatroomId 查找群聊，返回该条数据或 null */
   findOneByChatroomId(chatroomId) {
     const stmt = this.db.prepare('SELECT * FROM room WHERE chatroomId = ?');
     const row = stmt.get(chatroomId);
     if (row && row.memberList) {
-      row.memberList = JSON.parse(row.memberList); // 将 memberList 转换为 JSON 格式
+      row.memberList = JSON.parse(row.memberList); // 将 memberList 从 JSON 格式解析
     }
     return row ? row : null;
   }
-
+  /** 根据群聊名称查找群聊，返回该条数据或 null */
   findOneByChatroomName(name) {
     const stmt = this.db.prepare('SELECT * FROM room WHERE nickName = ?');
     const row = stmt.get(name);
     return row ? row : null;
   }
-
+  /** 根据群聊名称查找全部符合条件的群聊，返回数据数组或空数组 */
   findAllByChatroomName(name) {
     const stmt = this.db.prepare('SELECT * FROM room WHERE nickName = ?');
     const rows = stmt.all(name);
-    return rows.length > 0 ? rows : null;
+    return rows; // 当没有匹配的记录时，会返回空数组
   }
 
-  // 新增方法：更新room表中的memberList字段
+  /** 更新 room 表中的 memberList 字段，返回成功更改的记录数量 */
   updateRoomMemberList(chatroomId, memberList) {
     const existingRoom = this.findOneByChatroomId(chatroomId);
     if (!existingRoom) {
@@ -156,20 +158,22 @@ class myDB {
     `);
 
     // 将 memberList 转换为 JSON 字符串并更新
-    updateStmt.run(JSON.stringify(memberList), chatroomId);
+    const changes = updateStmt.run(JSON.stringify(memberList), chatroomId);
 
     console.log(`Updated memberList for room: ${chatroomId}`);
+
+    return changes;
   }
 
-  // 方法4：插入新的联系人数据，如果存在则更新
+  /** 插入新的联系人数据，如果存在则更新，返回成功更改的记录数量 */
   insertContact(contact) {
     if (contact.userName === null) {
       return;
     }
-  
+
     // 定义字段的最大长度
     const MAX_LENGTH = 255;
-  
+
     // 用一个函数来截断字符串
     const truncate = (value, maxLength = MAX_LENGTH) => {
       if (typeof value === 'string' && value.length > maxLength) {
@@ -177,7 +181,7 @@ class myDB {
       }
       return value;
     };
-  
+
     const insertStmt = this.db.prepare(`
       INSERT OR REPLACE INTO contact (
         userName, nickName, pyInitial, quanPin, sex, remark, remarkPyInitial,
@@ -185,8 +189,8 @@ class myDB {
         smallHeadImgUrl, description, cardImgUrl, labelList, province, city, phoneNumList
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
-  
-    insertStmt.run(
+
+    const changes = insertStmt.run(
       truncate(contact.userName) || null,
       truncate(contact.nickName) || null,
       truncate(contact.pyInitial) || null,
@@ -208,11 +212,13 @@ class myDB {
       truncate(contact.city) || null,
       truncate(contact.phoneNumList) || null
     );
-  
+
     console.log(`缓存联系人: ${contact.userName}`);
+
+    return changes;
   }
 
-  // 方法4：插入新的房间数据，如果存在则更新
+  /** 插入新的群聊数据，如果存在则更新，返回成功更改的记录数量 */
   insertRoom(room) {
     if(room.chatroomId === null){
       return
@@ -224,7 +230,7 @@ class myDB {
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
-    insertStmt.run(
+    const changes = insertStmt.run(
       room.chatroomId || null,
       room.nickName || null,
       room.pyInitial || null,
@@ -240,8 +246,11 @@ class myDB {
     );
 
     console.log(`缓存群: ${room.chatroomId}`);
+
+    return changes;
   }
-  // 方法5：更新联系人数据
+
+  /** 更新联系人数据，返回成功更改的记录数量 */
   updateContact(userName, newData) {
     const existingContact = this.findOneByUserName(userName);
     if (!existingContact) {
@@ -257,7 +266,7 @@ class myDB {
       WHERE userName = ?
     `);
 
-    updateStmt.run(
+    const changes = updateStmt.run(
       newData.nickName || existingContact.nickName,
       newData.pyInitial || existingContact.pyInitial,
       newData.quanPin || existingContact.quanPin,
@@ -281,9 +290,10 @@ class myDB {
     );
 
     console.log(`Updated contact: ${userName}`);
-  }
 
-  // 方法5：更新房间数据
+    return changes;
+  }
+  /** 更新群聊数据，返回成功更改的记录数量 */
   async updateRoom(chatroomId, newData) {
     const existingRoom = this.findOneByChatroomId(chatroomId);
     if (!existingRoom) {
@@ -297,12 +307,12 @@ class myDB {
         remarkQuanPin = ?, chatRoomNotify = ?, chatRoomOwner = ?, smallHeadImgUrl = ?, memberList = ?
       WHERE chatroomId = ?
     `);
-    
+
     const res = await getRoomMemberList(chatroomId) // 更新memberlist
     if(res && res.memberList){
       newData.memberList = res.memberList
     }
-    updateStmt.run(
+    const changes = updateStmt.run(
       newData.nickName || existingRoom.nickName,
       newData.pyInitial || existingRoom.pyInitial,
       newData.quanPin || existingRoom.quanPin,
@@ -318,15 +328,18 @@ class myDB {
     );
 
     console.log(`Updated room: ${chatroomId}`);
+
+    return changes;
   }
-  // 方法6：查询所有联系人数据
+
+  /** 查询所有联系人数据 */
   findAllContacts() {
     const stmt = this.db.prepare('SELECT * FROM contact');
     const rows = stmt.all(); // 获取所有记录
     return rows;
   }
 
-  // 方法7：查询所有房间数据
+  /** 查询所有群聊数据 */
   findAllRooms() {
     const stmt = this.db.prepare('SELECT * FROM room');
     const rows = stmt.all();
@@ -339,4 +352,4 @@ class myDB {
   }
 }
 
-export const db = new myDB();
+export const db = new MyDB();


### PR DESCRIPTION
## 完善 `GeweBot` 类的 `bot` 和对应的 `MyDB` 类相关类型定义，并简单梳理逻辑

### 现存问题

1. `index.d.ts` 类型声明中，`GeweBot.prototype.bot` 的类型被简单地定义为 `any`，这样会导致在使用 `bot` 时无法获得正确的类型提示
2. `src/sql/index.js` 的 `MyDB` 类中几个 `findAll...` 开头的方法，根据实际逻辑，应当返回对应结果类型组成的数组；即使没有找到对应结果，也应当返回空数组。但是现在的定义中返回的是 `null`，这样会导致在使用这些方法时遇到问题
3. 上述 `MyDB` 类中的几个 `update...` 和 `insert...` 开头的方法，根据实际逻辑，应当返回一个数字，表示操作是否成功，和受影响的行数。但是现在的定义中返回的是 `void`，这样会导致调用时无法得知操作是否成功

### 解决方案

1. 添加了类型声明文件 `src/sql/index.d.ts`，用于定义 `MyDB` 类的类型；对应修改了 `package.json`，添加必要的包，并将上述文件添加到 `files` 字段中
2. 修改了 `MyDB` 类中几个 `findAll...` 开头的方法，使其返回值类型为对应结果类型组成的数组，即使没有找到对应结果，也应当返回空数组
3. 修改了 `MyDB` 类中几个 `update...` 和 `insert...` 开头的方法，使其返回值类型为 `number`

### 向后兼容性

如果有人在使用这些方法时，依赖了上述第 2、3 点中的返回值作为 undefined，这一更改可能会造成兼容性问题。但由于这是非常规的用法，因此不考虑在这种情况下的兼容性破坏问题。

## 微调的小问题

- 微调 `Room.prototype.memberAll()` 程序逻辑中部分繁复啰嗦的语法
- 完善 `Room.prototype.memberList` 的类型定义（原本为  `any`）
- 修正 `GeweBot.prototype.start()` 的返回值类型（原本错误地使用 `import()` 导致实际被识别为 `any`）