### PR TITLE
修复 Docker 被重置后，回调会失败的问题，并在这种情况下会自动迁移数据

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import { type MyDB, type RoomMemberInDB } from './src/sql/index.d';
-import type Koa from 'koa';
-import type Router from 'koa-router';
+import type * as Koa from 'koa';
+import type * as Router from 'koa-router';
 
 declare module 'gewechaty' {
     export class GeweBot {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
   },
   "devDependencies": {
     "@swc/core": "^1.10.7",
+    "@types/koa": "^2.15.0",
+    "@types/koa-router": "^7.4.8",
+    "@types/koa-static": "^4.0.4",
     "@types/better-sqlite3": "^7.6.12",
     "@types/bun": "^1.2.3",
     "glob": "^11.0.0",

--- a/src/action/login.js
+++ b/src/action/login.js
@@ -62,35 +62,28 @@ const checkLogin = async() => {
   loginStatus = res.data.status
 }
 
-function waitForCondition() {
-  return new Promise((resolve) => {
-    function checkCondition() {
-      checkLogin().then(() => {
-        if (loginStatus === 2) {
-          // 条件满足，调用 resolve
-          resolve(true);
-        } else {
-          // 条件不满足，等待 5 秒后再次调用
-          console.log('请扫码登录...');
-          setTimeout(checkCondition, 5000);
-        }
-      }).catch(e => {
-        console.log('检查登录失败')
-        console.error(e)
-        resolve(false)
-      })
+async function waitForCondition() {
+  try {
+    while (true) {
+      await checkLogin(); // 检查登录状态
+      if (loginStatus === 2) {
+        return true; // 条件满足，返回 true
+      }
+      await new Promise((r) => setTimeout(r, 5000)); // 等待 5 秒后继续检查
     }
-    checkCondition();
-  });
+  } catch (error) {
+    console.log('检查登录失败');
+    console.error(error);
+    return false; // 发生错误时返回 false
+  }
 }
-
-
 
 export const login = async (callbackUrl) => {
   try{
     const res = await showQrcode()
     console.log('showQrcode:', res)
     if(res){
+      console.log('请扫码登录...');
       return await waitForCondition()
     }else{
       return false

--- a/src/action/login.js
+++ b/src/action/login.js
@@ -6,21 +6,21 @@ import { botEmitter } from '@/bot.js'
 let loginStatus = 0
 // const appId = getAppId()
 // 获取token
-export const getToken = async() => {
-  return new Promise((resolve, reject) => {
-    GetToken().then(res => {
-      if(res.ret === 200){
-        setToken(res.data)
-        resolve()
-      }else{ 
-        reject()
-      }
-    }).catch(e => {
-      reject(e)
-    })
-  })
-
+export const getToken = async (saveToStorage = true) => {
+  const res = await GetToken()
+  if (res.ret === 200) {
+    // 如果不保存到本地存储，则直接返回数据
+    if (!saveToStorage) {
+      return res.data
+    }
+    // 保存到本地存储，并返回数据
+    setToken(res.data)
+    return res.data
+  }
+  // 返回码不为200，抛出错误
+  throw res
 }
+
 // 展示二维码
 const showQrcode = async() => {
   await getToken()

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -35,7 +35,7 @@ function delay(ms) {
 app.use(bodyParser());
 
 
-export const startServe = (option) => {
+export const startServe = async (option) => {
   // 启动服务
   var cbip = option.ip || ip;
   let callBackUrl = `http://${cbip}:${option.port}${option.route}`
@@ -64,8 +64,7 @@ export const startServe = (option) => {
         if(s){
           console.log('断线重连成功')
         }else{
-          console.log('断线重连失败,请重新登录！')
-          process.exit(1);
+          throw new Error('断线重连失败,请重新登录！')
         }
       }
       

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,11 +1,12 @@
 import koa from 'koa'
-import koaRouter from 'koa-router'
+import * as koaRouter from 'koa-router'
 const { bodyParser } = require("@koa/bodyparser");
 import JSONbig from 'json-bigint'
 import serve from 'koa-static'
+import * as fsPromise from 'node:fs/promises'
 import { join } from 'path';
 import {setUrl} from '@/action/setUrl.js'
-import {login, reconnection} from '@/action/login.js'
+import {login, reconnection, getToken as getTokenFromDocker} from '@/action/login.js'
 import {cacheAllContact} from '@/action/contact'
 import {setCached} from '@/action/common'
 import {CheckOnline} from '@/api/login'
@@ -14,12 +15,12 @@ import {Message} from '@/class/MESSAGE.js'
 import {Contact} from '@/class/CONTACT.js'
 import {Room} from '@/class/ROOM.js'
 import { botEmitter, roomEmitter } from '@/bot.js'
-import { getAppId } from '@/utils/auth.js';
 import {db} from '@/sql/index.js'
 import {MessageType} from '@/type/MessageType'
 import {RoomInvitation} from '@/class/ROOMINVITATION.js'
 import {getRoomLiveInfo} from '@/action/room.js'
 import { Friendship } from '@/class/FRIENDSHIP';
+import * as ds from '@/utils/auth';
 export const bot = botEmitter
 export let staticUrl = 'static'
 export let proxyUrl = ''
@@ -59,15 +60,18 @@ export const startServe = async (option) => {
       bot.emit('all', body)
 
       if(body && body.TypeName === 'Offline'){
-        console.log('断线重连中...')
-        const s = await reconnection()
-        if(s){
-          console.log('断线重连成功')
-        }else{
-          throw new Error('断线重连失败,请重新登录！')
+        for (let i = 0; i < 3; i++) {
+          console.log('连接断开，5 秒后将尝试重连...')
+          await delay(5000)
+          const s = await reconnection()
+          if(s){
+            console.log('重连成功')
+            break
+          }
         }
+        throw new Error('断线重连失败达 3 次,请重新登录！')
       }
-      
+
       // 判断是否是微信消息
       if(body.Appid && body.TypeName === 'AddMsg'){ // 大部分消息类型都为 AddMsg
         // 消息hanlder
@@ -139,67 +143,104 @@ export const startServe = async (option) => {
   
   return new Promise((resolve, reject) => {
     app.listen(option.port, async (err) => {
+      // 启动服务失败
       if(err){
-        reject(err)
-        process.exit(1);
+        throw err
       }
 
-      try{
-        let isOnline = ''
-        if(getAppId()){ // 有appid时
-          isOnline = await CheckOnline({
-            appId: getAppId()
-          })
-        }else{
-          console.log('未设置appid，启动登录')
-          isOnline = {ret: 200, data: false}
-        }
-        
-        if(isOnline.ret === 200 && isOnline.data === false){
-          console.log('未登录')
-          const loginRes = await login()
-          if(!loginRes){
-            console.log('登录失败')
-            process.exit(1);
+      /** 用于保存登录状态 */
+      let onlineStatus = { ret: 200, data: false }
+
+      // 先从 DS 和 Docker 获取 token / appid
+      const oldAppId = ds.getAppId()
+      const oldToken = ds.getToken()
+      const currentToken = await getTokenFromDocker()
+
+      if (oldToken !== currentToken) { // token 变化，意味着 Docker 状态被重置
+        console.log('Docker 状态被重置，程序将迁移数据，需要重新登录...')
+
+        // 储存新的 token
+        ds.setToken(currentToken)
+
+        // 状态被重置后，appid 失效，所以在 DS 中清空
+        ds.setAppId('')
+      } else if (oldAppId) { // 若已经设置 appid，通过 CheckOnline 接口验证当前登录状态
+        onlineStatus = await CheckOnline({
+          appId: ds.getAppId()
+        })
+      } else {
+        console.log('未设置 appid，启动登录流程...')
+      }
+
+      // 若无法获取到登录状态，则进入登录流程
+      if(onlineStatus.ret === 200 && onlineStatus.data === false){
+        await login().then((res) => {
+          if (!res) { // TODO: 登录逻辑应该把错误原因抛出，而不是返回 false
+            throw new Error('登录遇到问题')
           }
-        }
-        setCached(true)
-        const dbPath = join(option.data_dir, getAppId() + '.db')
-        if(!db.exists(dbPath)){
+        }).catch((e) => { // 无论是上一段抛出的错误，还是 login() 抛出的，都会进入这里
+          console.error('登录失败：\n', e)
+          throw e // 会被直接抛出 startServe 以外，阻止后续代码执行
+        })
+      }
+
+      // 登录成功后，获取当前 appid，并拼接数据库路径
+      const currentAppId = ds.getAppId()
+      const dbPath = join(option.data_dir, currentAppId + '.db')
+
+      // 如果数据库文件不存在，需要初始化数据库
+      if(!db.exists(dbPath)){
+        // 如果之前 token 被重置过，将尝试修改缓存数据库文件名，以避免重新生成数据库
+        // 如果 appid 被清空，上面的登录逻辑会通过以下链条确保 appid 被重新生成且被存入 DS：
+        // login() ->
+        // showQrcode() [to get appid via `(await GetQrcode()).data.appId`] ->
+        // setAppId()
+        if (oldToken !== currentToken && db.exists(join(option.data_dir, oldAppId + '.db'))) { // token 变化，且旧数据库文件存在
+            // 用拷贝-删除替代重命名，以避免旧的数据库文件被占用导致无法重命名
+            await fsPromise.copyFile(join(option.data_dir, oldAppId + '.db'), join(option.data_dir, currentAppId + '.db'))
+            // 删除失败只会在控制台输出错误，不会影响程序运行
+            fsPromise.rm(join(option.data_dir, oldAppId + '.db')).catch(console.error)
+
+            // 连接数据库
+            db.connect(dbPath)
+            console.log('成功迁移旧的数据缓存，启用缓存')
+        } else { // 否则视作首次登录，直接创建数据库
           console.log('创建本地数据库，启用缓存')
+          console.log('本地数据初始化，可能需要耗费点时间，耐心等待...')
+
+          // 连接数据库，这一情况下由于数据库文件不存在，会自动创建数据库文件
           db.connect(dbPath)
-          // 创建表
+
+          // 创建数据表
           db.createContactTable()
           db.createRoomTable()
-          // 缓存所有联系人 并保存到本地数据库
-          console.log('本地数据初始化，可能需要耗费点时间，耐心等待...')
-          await delay(1000) // 防止异步
+
+          // 防止异步
+          // NOTE: 上面两个函数调用的 this.db.exec 好像是同步的，不应该需要 delay？待确认……
+          await delay(1000)
+
+          // 缓存所有联系人并保存到本地数据库
           await cacheAllContact()
           console.log('数据初始化完毕')
-        }else{
-          db.connect(dbPath)
-          console.log('存在缓存数据，启用缓存')
         }
+      } else {
+        db.connect(dbPath)
+        console.log('存在缓存数据，启用缓存')
+      }
+      setCached(true) // NOTE: 对应的状态好像没用上
         
-        // 此时再启用回调地址 防止插入数据时回调
-        app.use(router.routes())
-        app.use(router.allowedMethods())
+      // 此时再启用回调地址 防止插入数据时回调
+      app.use(router.routes())
+      app.use(router.allowedMethods())
 
-        const res = await setUrl(callBackUrl)
-        if(res.ret === 200){
-          console.log(`设置回调地址为：${callBackUrl}`)
-          console.log('服务启动成功')
-          resolve({app, router})
-        }else{
-          console.log('回调地址设置失败，请确定gewechat能访问到回调地址网络: ', callBackUrl)
-          reject(res)
-          process.exit(1);
-        }
-      }catch(e){
-        console.log('服务启动失败')
-        console.error(e)
-        reject(e)
-        process.exit(1);
+      // 为 Docker 设置回调地址
+      const res = await setUrl(callBackUrl)
+      if (res.ret === 200) {
+        console.log(`设置回调地址为：${callBackUrl}`)
+        console.log('服务启动成功')
+        resolve({app, router})
+      } else { // 回调 API 对于 Docker 而言不可达
+        throw new Error('回调地址设置失败，请确定 Gewechat 能访问到回调地址: ' + callBackUrl, { detail: res })
       }
     }).on('error', (err) => {
       if (err.code === 'EADDRINUSE') {


### PR DESCRIPTION
修复问题 #43：重置 Docker 容器状态后，Docker 的 token 和设备 ID 会发生变化，用旧的信息连接会失败。

修复方式为：在每次登录之前，检查一次 token 是否改变。若改变，则登录时重新获取设备 ID，并重新登录。获取设备 ID 成功后，将旧的缓存数据库重命名为新的 ID，以避免重建数据缓存。

⚠ **已知的 bug：自动迁移数据之后，第一次登录会收到一条消息，紧接着会掉线，且无法自动重连，需要手动重新连接。**

尝试过无效的方案：
- 递归调用 `startServe()`
- 在 `startServe()` 末尾自动 `exit()` 退出

以上方案均不能解决问题，必须先收到登录消息，掉线后再手动重新连接。

但即使这样，也比要手动删除数据好一点了……

除此之外，本 PR 还移除了所有 `process.exit(1)` 代码。作为一个 npm 模块，出现错误应当抛出给调用者，让调用者自行选择 catch / fallback / panic 等处理方式，直接退出程序实在不合适。
